### PR TITLE
Don't fetch available days when no products have been selected

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## unreleased
 * Option `showSubmit` for contact forms (only used internally) is now named `standalone`. The old option will remain as alias until the next major version
 * Better error messages for standalone contact forms
+* Don't fetch available days when no products have been selected
 
 ## 1.2.1 (2019-12-18)
 * Fix error when trying to book a product that has no material


### PR DESCRIPTION
Currently, available days are fetched straight away after choosing a package. No products have been selected at that time, so the available days check will always return an empty array.
This PR removes that first check.

For best comparison, click the cog icon and choose "Hide whitespace changes"

Refs #20