### PR TITLE
Fetch available days differently

### DIFF
--- a/src/booking.js
+++ b/src/booking.js
@@ -1044,18 +1044,10 @@ class RecrasBooking {
                         },
                         field: this.findElement('.recras-onlinebooking-date'),
                         i18n: RecrasCalendarHelper.i18n(this.languageHelper),
-                        onDraw: (pika) => {
-                            let lastMonthYear = pika.calendars[pika.calendars.length - 1];
-                            let lastDay = new Date(lastMonthYear.year, lastMonthYear.month, 31);
-
+                        onDraw: () => {
                             let lastAvailableDay = this.lastAvailableDate();
-                            if (lastAvailableDay > lastDay) {
-                                return;
-                            }
-
                             let newEndDate = RecrasDateHelper.clone(lastAvailableDay);
-                            newEndDate.setFullYear(lastMonthYear.year);
-                            newEndDate.setMonth(lastMonthYear.month + 2);
+                            newEndDate.setMonth(newEndDate.getMonth() + 1);
 
                             this.getAvailableDays(pack.id, lastAvailableDay, newEndDate);
                         },
@@ -1281,7 +1273,7 @@ ${ msgs[1] }</p></div>`);
 
         let datePickerEl = this.findElement('.recras-onlinebooking-date');
 
-        var thisClass = this;
+        const thisClass = this;
         maxPromise.then(function() {
             let amountErrors = thisClass.findElements(
                 '.minimum-amount, .maximum-amount, .recras-product-dependency'
@@ -1296,7 +1288,7 @@ ${ msgs[1] }</p></div>`);
             thisClass.loadingIndicatorShow(thisClass.findElement('label[for="recras-onlinebooking-date"]'));
             let startDate = new Date();
             let endDate = new Date();
-            endDate.setMonth(endDate.getMonth() + 3);
+            endDate.setMonth(endDate.getMonth() + 6);
 
             thisClass.getAvailableDays(thisClass.selectedPackage.id, startDate, endDate)
                 .then(availableDays => {

--- a/src/booking.js
+++ b/src/booking.js
@@ -5,6 +5,7 @@
 
 class RecrasBooking {
     constructor(options = {}) {
+        this.availableDays = [];
         this.datePicker = null;
 
         this.PAYMENT_DIRECT = 'mollie';
@@ -1009,6 +1010,17 @@ class RecrasBooking {
         </form>`;
         this.appendHtml(html);
     }
+
+    lastAvailableDate() {
+        let lastAvailableDay = this.availableDays.reduce((acc, curVal) => {
+            return curVal > acc ? curVal : acc;
+        }, '');
+        if (lastAvailableDay) {
+            return new Date(lastAvailableDay);
+        }
+        return new Date();
+    }
+
     showDateTimeSelection(pack) {
         let startDate = new Date();
         let endDate = new Date();
@@ -1036,14 +1048,7 @@ class RecrasBooking {
                             let lastMonthYear = pika.calendars[pika.calendars.length - 1];
                             let lastDay = new Date(lastMonthYear.year, lastMonthYear.month, 31);
 
-                            let lastAvailableDay = this.availableDays.reduce((acc, curVal) => {
-                                return curVal > acc ? curVal : acc;
-                            }, '');
-                            if (!lastAvailableDay) {
-                                lastAvailableDay = new Date();
-                            } else {
-                                lastAvailableDay = new Date(lastAvailableDay);
-                            }
+                            let lastAvailableDay = this.lastAvailableDate();
                             if (lastAvailableDay > lastDay) {
                                 return;
                             }

--- a/test/js-unit/recrasBookingSpec.js
+++ b/test/js-unit/recrasBookingSpec.js
@@ -131,6 +131,26 @@ describe('RecrasBooking', () => {
         });
     });
 
+    describe('lastAvailableDate', () => {
+        beforeEach(() => {
+            this.rb = new RecrasBooking(new RecrasOptions({
+                element: document.createElement('div'),
+                recras_hostname: 'demo.recras.nl',
+            }));
+        });
+
+        it('returns today when there are no available days yet', () => {
+            let date = this.rb.lastAvailableDate();
+            expect(date.toDateString()).toEqual((new Date()).toDateString());
+        });
+
+        it('returns last available date', () => {
+            this.rb.availableDays = ['2020-01-01', '2019-12-31'];
+            let date = this.rb.lastAvailableDate();
+            expect(date.toDateString()).toEqual((new Date('2020-01-01')).toDateString());
+        });
+    });
+
     describe('bookingSizeMaximum', () => {
         beforeEach(() => {
             this.rb = new RecrasBooking(new RecrasOptions({


### PR DESCRIPTION
- fetch 6 months instead of 3 months initially
- fetch 1 month each time the calendar draws a new month

This PR does not address the issue that changing month/year in the header (didn't even know that was possible until 5 minutes ago) doesn't work. This could be addressed in a follow-up issue.