### PR TITLE
Improve interaction (particularly on mobile)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * Better error messages for standalone contact forms
 * Don't fetch available days when no products have been selected
 * Add missing error message for minimum amount
+* Improve interaction (particularly on mobile)
 
 ## 1.2.1 (2019-12-18)
 * Fix error when trying to book a product that has no material

--- a/src/booking.js
+++ b/src/booking.js
@@ -1014,7 +1014,7 @@ class RecrasBooking {
             <label for="recras-onlinebooking-date">
                 ${ this.languageHelper.translate('DATE') }
             </label>
-            <input type="text" id="recras-onlinebooking-date" class="recras-onlinebooking-date" min="${ today }" disabled autocomplete="off">
+            <input type="text" id="recras-onlinebooking-date" class="recras-onlinebooking-date" min="${ today }" disabled readonly autocomplete="off">
             <label for="recras-onlinebooking-time">
                 ${ this.languageHelper.translate('TIME') }
             </label>

--- a/src/cssHelper.js
+++ b/src/cssHelper.js
@@ -127,6 +127,11 @@ button .recrasLoadingIndicator {
     font-weight: bold;
     padding: 0.5em 2em;
 }
+@media (max-width: 520px) {
+    .pika-single {
+        max-width: 256px; /* Single month is 240px + 2x8px margin */
+    }
+}
 `;
     }
 


### PR DESCRIPTION
- don't allow user input for the date, since this breaks unless you use exact DD-MM-YYYY format
- calendar styling on small screens

Tested in Chrome on Android, Chrome on Ubuntu, Firefox on Ubuntu, IE11 on Windows 10, (EdgeHTML based) Edge on Windows 10