### PR TITLE
Update event sending for GA integrated through GTM

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Update event sending for Google Analytics integrated through Google Tag Manager
+
 ## 1.3.2 (2019-02-03)
 * Fix amount inputs in Firefox
 

--- a/src/eventHelper.js
+++ b/src/eventHelper.js
@@ -85,7 +85,12 @@ class RecrasEventHelper {
                 if (value) {
                     eventData.eventValue = value;
                 }
-                window.ga('send', eventData);
+                // Google Analytics via Google Tag Manager doesn't work without a prefix
+                let prefix = window.ga.getAll()[0].get('name');
+                if (prefix) {
+                    prefix += '.';
+                }
+                window.ga(prefix + 'send', eventData);
             }
         }
 


### PR DESCRIPTION
Analytics integrated via Google Tag Manager need the tracker prefix, otherwise no events are sent