### PR TITLE
Fix discount code with prefilled date

### DIFF
--- a/src/booking.js
+++ b/src/booking.js
@@ -409,7 +409,7 @@ class RecrasBooking {
     checkDiscountAndVoucher() {
         let discountPromise = this.checkDiscountcode(
             this.selectedPackage.id,
-            this.findElement('.recras-onlinebooking-date').value,
+            RecrasDateHelper.datePartOnly(this.selectedDate),
             this.findElement('#discountcode').value.trim()
         );
 


### PR DESCRIPTION
Prefilled date does not have a value in the input box, this always uses the proper value