### PR TITLE
Add support for Google Analytics v4 (GA4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The library sends out a few custom events when certain things change:
 You can use these events for custom actions, such as analytics. For use in code, please refer to 
 the constants in [src/eventHelper.js](src/eventHelper.js).
 
-When Google Analytics integration is enabled, certain events sent to GA include a label and/or value:
+When Google Analytics integration is enabled, certain events are sent to GA. Which events are sent depends on the version of GA you are using. For Universal Analytics (v3) and older, these custom events are sent and they include a label and/or value:
 
 | Event                              | Label                             | Value                               |
 | ---------------------------------- | --------------------------------- |-------------------------------------|
@@ -140,3 +140,8 @@ When Google Analytics integration is enabled, certain events sent to GA include 
 | `Recras:Voucher:TemplateChanged`   | N/A                               | Template ID                         |
 | `Recras:Voucher:BuyInProgress`     | Template name                     | Rounded total amount of the order   |
 | `Recras:Voucher:RedirectToPayment` | N/A                               | Rounded total amount of the order   |
+
+For GA4, these events are sent:
+* when a package is selected: `select_content`. The ID of the package is included.
+* when a voucher is selected: `select_content`. The ID of the template is included.
+* when the user is redirected to the payment provider: `begin_checkout`. The total amount as well as all selected items (name, price, quantity) are included.

--- a/src/booking.js
+++ b/src/booking.js
@@ -318,7 +318,11 @@ class RecrasBooking {
                 RecrasEventHelper.PREFIX_BOOKING,
                 RecrasEventHelper.EVENT_BOOKING_PACKAGE_CHANGED,
                 selectedPackage[0].arrangement,
-                selectedPackage[0].id
+                selectedPackage[0].id,
+                {
+                    content_type: 'package',
+                    item_id: selectedPackage[0].id,
+                }
             );
         }
         this.selectedPackage = selectedPackage[0];
@@ -1432,7 +1436,12 @@ ${ msgs[1] }</p></div>`);
                     RecrasEventHelper.PREFIX_BOOKING,
                     RecrasEventHelper.EVENT_BOOKING_REDIRECT_PAYMENT,
                     null,
-                    Math.round(this.getTotalPrice())
+                    Math.round(this.getTotalPrice()),
+                    {
+                        currency: this.languageHelper.currency,
+                        value: this.getTotalPrice(),
+                        items: [], //TODO?
+                    }
                 );
                 window.top.location.href = json.payment_url;
             } else if (json.redirect) {

--- a/src/booking.js
+++ b/src/booking.js
@@ -769,7 +769,6 @@ class RecrasBooking {
         if (!button) {
             return false;
         }
-        console.log(this.formatGA4Items());
 
         let bookingDisabledReasons = [];
         if (this.requiresProduct) {

--- a/src/eventHelper.js
+++ b/src/eventHelper.js
@@ -63,7 +63,7 @@ class RecrasEventHelper {
 
     isGA4() {
         const fn = window[window.GoogleAnalyticsObject || 'ga'];
-        return fn.h && fn.h.gtm4;
+        return fn && fn.h && fn.h.gtm4;
     }
 
     sendEvent(cat, action, label = undefined, value = undefined, ga4Value = undefined) {

--- a/src/eventHelper.js
+++ b/src/eventHelper.js
@@ -49,11 +49,12 @@ class RecrasEventHelper {
     }
 
     ga4EventMap(action) {
-        let map = {};
-        map[RecrasEventHelper.EVENT_BOOKING_PACKAGE_CHANGED] = 'select_content';
-        map[RecrasEventHelper.EVENT_BOOKING_REDIRECT_PAYMENT] = 'begin_checkout';
-        map[RecrasEventHelper.EVENT_VOUCHER_TEMPLATE_CHANGED] = 'select_content';
-        map[RecrasEventHelper.EVENT_VOUCHER_REDIRECT_PAYMENT] = 'begin_checkout';
+        let map = {
+            [RecrasEventHelper.EVENT_BOOKING_PACKAGE_CHANGED]: 'select_content',
+            [RecrasEventHelper.EVENT_BOOKING_REDIRECT_PAYMENT]: 'begin_checkout',
+            [RecrasEventHelper.EVENT_VOUCHER_TEMPLATE_CHANGED]: 'select_content',
+            [RecrasEventHelper.EVENT_VOUCHER_REDIRECT_PAYMENT]: 'begin_checkout',
+        };
 
         if (map[action] === undefined) {
             return false;

--- a/src/vouchers.js
+++ b/src/vouchers.js
@@ -72,7 +72,12 @@ class RecrasVoucher {
                         RecrasEventHelper.PREFIX_VOUCHER,
                         RecrasEventHelper.EVENT_VOUCHER_REDIRECT_PAYMENT,
                         null,
-                        Math.round(this.totalPrice())
+                        Math.round(this.totalPrice()),
+                        {
+                            currency: this.languageHelper.currency,
+                            value: this.totalPrice(),
+                            items: [], //TODO?
+                        }
                     );
                     window.top.location.href = json.payment_url;
                 } else {
@@ -94,7 +99,11 @@ class RecrasVoucher {
             RecrasEventHelper.PREFIX_VOUCHER,
             RecrasEventHelper.EVENT_VOUCHER_TEMPLATE_CHANGED,
             null,
-            templateID
+            templateID,
+            {
+                content_type: 'voucher',
+                item_id: templateID,
+            }
         );
     }
 

--- a/src/vouchers.js
+++ b/src/vouchers.js
@@ -43,6 +43,16 @@ class RecrasVoucher {
         this.element.insertAdjacentHTML('beforeend', msg);
     }
 
+    formatGA4Item() {
+        return [
+            {
+                item_name: this.selectedTemplate.name,
+                price: this.selectedTemplate.price,
+                quantity: parseInt(this.findElement('#number-of-vouchers').value),
+            }
+        ];
+    }
+
     buyTemplate() {
         let status = this.contactForm.checkRequiredCheckboxes();
         if (!status) {
@@ -76,7 +86,7 @@ class RecrasVoucher {
                         {
                             currency: this.languageHelper.currency,
                             value: this.totalPrice(),
-                            items: [], //TODO?
+                            items: this.formatGA4Item(),
                         }
                     );
                     window.top.location.href = json.payment_url;


### PR DESCRIPTION
Custom events in GA4 are different: "[Custom events don't show up in most standard reports. You need to set up custom reports for meaningful analysis](https://support.google.com/analytics/answer/9322688?hl=en)" and I'm not sure you can even create them from a script or if you need to manually add them through the GA interface. So, for GA4 only a few events remain. We might add more later on if we get feedback on that.