### PR TITLE
Remove old browser support

### DIFF
--- a/src/booking.js
+++ b/src/booking.js
@@ -945,15 +945,7 @@ class RecrasBooking {
         }
         this.findElement('#recras-onlinebooking-time option[value]').selected = true;
 
-        let event;
-        try {
-            event = new Event('change');
-        } catch (e) {
-            // IE
-            event = document.createEvent('Event');
-            event.initEvent('change', true, true);
-        }
-        this.findElement('#recras-onlinebooking-time').dispatchEvent(event);
+        this.findElement('#recras-onlinebooking-time').dispatchEvent(new Event('change'));
     }
 
     setDiscountStatus(statusText, isError = true) {

--- a/src/contactForm.js
+++ b/src/contactForm.js
@@ -77,10 +77,6 @@ class RecrasContactForm {
     }
 
     isStandalone(options) {
-        if (options.showSubmit) {
-            console.warn('Option "showSubmit" was renamed to "standalone". Please update your code.');
-            options.standalone = true;
-        }
         return !!options.standalone;
     }
 

--- a/src/cssHelper.js
+++ b/src/cssHelper.js
@@ -9,22 +9,11 @@ class RecrasCSSHelper {
     border-top: 2px solid #dedede; /* Any love for Kirby out there? */
 }
 .recras-amountsform > div {
-    display: -ms-grid;
     display: grid;
-    -ms-grid-columns: 1fr 5em 7em;
     grid-template-columns: 1fr 5em 7em;
-}
-.recras-amountsform > div > div:first-child {
-    -ms-grid-column: 1;
-}
-.recras-amountsform > div > input {
-    -ms-grid-column: 2;
 }
 .recras-amountsform input {
     width: auto; /* Firefox fix */
-}
-.recras-amountsform > div > div:last-child {
-    -ms-grid-column: 3;
 }
 .recras-input-invalid {
     border: 1px solid hsl(0, 50%, 50%);
@@ -39,9 +28,7 @@ class RecrasCSSHelper {
     padding-left: 0.5em;
 }
 .recras-datetime {
-    display: -ms-grid;
     display: grid;
-    -ms-grid-columns: 30% 70%;
     grid-template-columns: 30% 70%;
 }
 .recras-datetime > * {
@@ -49,17 +36,9 @@ class RecrasCSSHelper {
 }
 .recras-datetime label {
     display: block;
-    -ms-grid-column: 1;
 }
 .recras-datetime input, .recras-datetime select {
     max-width: 12em;
-    -ms-grid-column: 2;
-}
-.recras-datetime > :nth-child(-n + 2) {
-    -ms-grid-row: 1;
-}
-.recras-datetime > :nth-last-child(-n + 2) {
-    -ms-grid-row: 2;
 }
 .time-preview {
     padding-right: 0.5em;
@@ -82,9 +61,7 @@ class RecrasCSSHelper {
     padding: 1em 0;
 }
 .recras-datetime, .recras-discounts > div, .recras-contactform > div {
-    display: -ms-grid;
     display: grid;
-    -ms-grid-columns: 1fr 12em;
     grid-template-columns: 1fr 12em;
 }
 .recras-contactform > div {
@@ -94,14 +71,8 @@ class RecrasCSSHelper {
 .recras-contactform label {
     display: block;
 }
-.recras-contactform > div > :last-child {
-    -ms-grid-column: 2;
-}
 .recras-amountsform .recras-full-width {
     display: block;
-}
-.recras-discounts > div > input {
-    -ms-grid-column: 2;
 }
 
 .recrasLoadingIndicator {

--- a/src/eventHelper.js
+++ b/src/eventHelper.js
@@ -68,16 +68,6 @@ class RecrasEventHelper {
     }
 
     sendEvent(cat, action, label = undefined, value = undefined, ga4Value = undefined) {
-        let event;
-
-        try {
-            event = new Event(RecrasEventHelper.PREFIX_GLOBAL + ':' + cat + ':' + action);
-        } catch (e) {
-            // IE
-            event = document.createEvent('Event');
-            event.initEvent(action, true, true);
-        }
-
         if (this.analyticsEnabled && this.eventEnabled(action)) {
             if (this.isGA4() && this.ga4EventMap(action) && ga4Value) {
                 // v4
@@ -118,6 +108,7 @@ class RecrasEventHelper {
             }
         }
 
+        const event = new Event(RecrasEventHelper.PREFIX_GLOBAL + ':' + cat + ':' + action);
         return document.dispatchEvent(event);
     }
 

--- a/upgrading.md
+++ b/upgrading.md
@@ -1,5 +1,6 @@
 # 1.11.0 -> 2.0.0
 * Support for Internet Explorer (all versions) and old Edge (12-15) has been removed.
+* Option `showSubmit` has been removed. It was renamed to `standalone` in version 1.3.0
 
 # 1.10.2 -> 1.10.3
 * The value of "BuyInProgress" events sent to Google Analytics was changed from package ID to total price. This is true for both bookings and vouchers. We consider this a bugfix and not a backwards-compatibility breaking change.

--- a/upgrading.md
+++ b/upgrading.md
@@ -1,5 +1,5 @@
 # 1.11.0 -> 2.0.0
-* Support for Internet Explorer (all versions) has been removed.
+* Support for Internet Explorer (all versions) and old Edge (12-15) has been removed.
 
 # 1.10.2 -> 1.10.3
 * The value of "BuyInProgress" events sent to Google Analytics was changed from package ID to total price. This is true for both bookings and vouchers. We consider this a bugfix and not a backwards-compatibility breaking change.

--- a/upgrading.md
+++ b/upgrading.md
@@ -1,3 +1,6 @@
+# 1.11.0 -> 2.0.0
+* Support for Internet Explorer (all versions) has been removed.
+
 # 1.10.2 -> 1.10.3
 * The value of "BuyInProgress" events sent to Google Analytics was changed from package ID to total price. This is true for both bookings and vouchers. We consider this a bugfix and not a backwards-compatibility breaking change.
 


### PR DESCRIPTION
#198 has been merged, which will introduce breaking changes when released. In version 1.3.0 we deprecated an option, which should be removed in this new version. Let's take the opportunity to drop support for Internet Explorer (EOL next month, roughly 0.5% usage in the Netherlands) and old Edge (12-15, all over 5 years old, 0% usage in the Netherlands)