### PR TITLE
Contact form time field only allowed time in 5-minute intervals

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Contact form time field only allowed time in 5-minute intervals, but browser time pickers don't show this in their UI. Removed this limitation.
+
 ## 2.0.4 (2022-10-07)
 * Contact form/Voucher sales no longer shows error messages inline, but after the form
 

--- a/src/contactForm.js
+++ b/src/contactForm.js
@@ -344,7 +344,7 @@ class RecrasContactForm {
                 return label + `<input type="number" ${ fixedAttributes } min="1">`;
             case 'boeking.starttijd':
                 placeholder = this.languageHelper.translate('TIME_FORMAT');
-                return label + `<input type="time" ${ fixedAttributes } placeholder="${ placeholder }" pattern="${ timePattern }" step="300">`;
+                return label + `<input type="time" ${ fixedAttributes } placeholder="${ placeholder }" pattern="${ timePattern }">`;
             case 'boeking.arrangement':
                 const preFilledPackage = this.options.getPackageId();
                 if (field.verplicht && this.packages.length === 1) {


### PR DESCRIPTION
but browser time pickers don't show this in their UI. Removed this limitation.